### PR TITLE
Add Composable Previews

### DIFF
--- a/app/src/main/java/com/example/restaurantmanager/ui/customer/screen/CartScreen.kt
+++ b/app/src/main/java/com/example/restaurantmanager/ui/customer/screen/CartScreen.kt
@@ -4,15 +4,17 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.restaurantmanager.data.local.model.CartItem
+import com.example.restaurantmanager.data.local.model.MenuItem
 import com.example.restaurantmanager.ui.customer.viewmodel.CartViewModel
+import com.example.restaurantmanager.ui.theme.RestaurantManagerTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -22,6 +24,32 @@ fun CartScreen(
 ) {
     val cartItems = cartViewModel.cartItems
 
+    CartScreenContent(
+        cartItems = cartItems,
+        subtotal = cartViewModel.subtotal,
+        parcelCharges = cartViewModel.parcelCharges,
+        grandTotal = cartViewModel.grandTotal,
+        onNavigateToCheckout = onNavigateToCheckout,
+        onDineInQuantityChanged = { cartItem, quantity -> cartViewModel.onDineInQuantityChanged(cartItem, quantity) },
+        onTakeawayQuantityChanged = { cartItem, quantity -> cartViewModel.onTakeawayQuantityChanged(cartItem, quantity) },
+        onInstructionsChanged = { cartItem, instructions -> cartViewModel.onInstructionsChanged(cartItem, instructions) },
+        onRemoveItem = { cartViewModel.removeItem(it) }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CartScreenContent(
+    cartItems: List<CartItem>,
+    subtotal: Double,
+    parcelCharges: Double,
+    grandTotal: Double,
+    onNavigateToCheckout: () -> Unit,
+    onDineInQuantityChanged: (CartItem, Int) -> Unit,
+    onTakeawayQuantityChanged: (CartItem, Int) -> Unit,
+    onInstructionsChanged: (CartItem, String) -> Unit,
+    onRemoveItem: (CartItem) -> Unit
+) {
     Scaffold(
         topBar = {
             TopAppBar(title = { Text("Your Cart") })
@@ -40,14 +68,14 @@ fun CartScreen(
                             horizontalArrangement = Arrangement.SpaceBetween
                         ) {
                             Text("Subtotal:")
-                            Text("₹${cartViewModel.subtotal}")
+                            Text("₹${subtotal}")
                         }
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.SpaceBetween
                         ) {
                             Text("Parcel Charges:")
-                            Text("₹${cartViewModel.parcelCharges}")
+                            Text("₹${parcelCharges}")
                         }
                         Divider(modifier = Modifier.padding(vertical = 8.dp))
                         Row(
@@ -55,7 +83,7 @@ fun CartScreen(
                             horizontalArrangement = Arrangement.SpaceBetween
                         ) {
                             Text("Grand Total:", style = MaterialTheme.typography.titleLarge)
-                            Text("₹${cartViewModel.grandTotal}", style = MaterialTheme.typography.titleLarge)
+                            Text("₹${grandTotal}", style = MaterialTheme.typography.titleLarge)
                         }
                         Spacer(modifier = Modifier.height(16.dp))
                         Button(
@@ -78,10 +106,10 @@ fun CartScreen(
             items(cartItems) { cartItem ->
                 CartItemCard(
                     cartItem = cartItem,
-                    onDineInQuantityChanged = { quantity -> cartViewModel.onDineInQuantityChanged(cartItem, quantity) },
-                    onTakeawayQuantityChanged = { quantity -> cartViewModel.onTakeawayQuantityChanged(cartItem, quantity) },
-                    onInstructionsChanged = { instructions -> cartViewModel.onInstructionsChanged(cartItem, instructions) },
-                    onRemoveItem = { cartViewModel.removeItem(cartItem) }
+                    onDineInQuantityChanged = { quantity -> onDineInQuantityChanged(cartItem, quantity) },
+                    onTakeawayQuantityChanged = { quantity -> onTakeawayQuantityChanged(cartItem, quantity) },
+                    onInstructionsChanged = { instructions -> onInstructionsChanged(cartItem, instructions) },
+                    onRemoveItem = { onRemoveItem(cartItem) }
                 )
             }
         }
@@ -171,5 +199,37 @@ fun QuantitySelector(
         IconButton(onClick = { onQuantityChanged(quantity + 1) }) {
             Text("+")
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CartScreenPreview() {
+    RestaurantManagerTheme {
+        val cartItems = listOf(
+            CartItem(
+                menuItem = MenuItem(id = 1, name = "Paneer Tikka", description = "Grilled cottage cheese cubes marinated in spices", price = 250.0, category = "Starters", in_stock = true),
+                dineInQuantity = 1,
+                takeawayQuantity = 1,
+                instructions = "Make it spicy"
+            ),
+            CartItem(
+                menuItem = MenuItem(id = 3, name = "Dal Makhani", description = "Creamy black lentils cooked with butter and spices", price = 300.0, category = "Main Course", in_stock = true),
+                dineInQuantity = 2,
+                takeawayQuantity = 0,
+                instructions = ""
+            )
+        )
+        CartScreenContent(
+            cartItems = cartItems,
+            subtotal = 850.0,
+            parcelCharges = 20.0,
+            grandTotal = 870.0,
+            onNavigateToCheckout = {},
+            onDineInQuantityChanged = { _, _ -> },
+            onTakeawayQuantityChanged = { _, _ -> },
+            onInstructionsChanged = { _, _ -> },
+            onRemoveItem = {}
+        )
     }
 }

--- a/app/src/main/java/com/example/restaurantmanager/ui/customer/screen/MenuScreen.kt
+++ b/app/src/main/java/com/example/restaurantmanager/ui/customer/screen/MenuScreen.kt
@@ -14,11 +14,13 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.restaurantmanager.data.local.model.MenuItem
 import com.example.restaurantmanager.ui.customer.viewmodel.CartViewModel
 import com.example.restaurantmanager.ui.customer.viewmodel.MenuViewModel
+import com.example.restaurantmanager.ui.theme.RestaurantManagerTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -31,6 +33,24 @@ fun MenuScreen(
     val menuItems by menuViewModel.menuItems.collectAsState()
     val cartItemCount = cartViewModel.cartItems.size
 
+    MenuScreenContent(
+        menuItems = menuItems,
+        cartItemCount = cartItemCount,
+        onNavigateToCart = onNavigateToCart,
+        onNavigateToAdmin = onNavigateToAdmin,
+        onAddToCart = { cartViewModel.addItem(it) }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MenuScreenContent(
+    menuItems: Map<String, List<MenuItem>>,
+    cartItemCount: Int,
+    onNavigateToCart: () -> Unit,
+    onNavigateToAdmin: () -> Unit,
+    onAddToCart: (MenuItem) -> Unit
+) {
     Scaffold(
         topBar = {
             TopAppBar(
@@ -70,7 +90,7 @@ fun MenuScreen(
                 if (isExpanded) {
                     items(items) { menuItem ->
                         MenuItemCard(menuItem, onAddToCart = {
-                            cartViewModel.addItem(menuItem)
+                            onAddToCart(menuItem)
                         })
                     }
                 }
@@ -146,5 +166,29 @@ fun MenuItemCard(menuItem: MenuItem, onAddToCart: () -> Unit) {
                 }
             }
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MenuScreenPreview() {
+    RestaurantManagerTheme {
+        val menuItems = mapOf(
+            "Starters" to listOf(
+                MenuItem(id = 1, name = "Paneer Tikka", description = "Grilled cottage cheese cubes marinated in spices", price = 250.0, category = "Starters", in_stock = true),
+                MenuItem(id = 2, name = "Chilli Potato", description = "Crispy fried potatoes tossed in a spicy sauce", price = 180.0, category = "Starters", in_stock = true)
+            ),
+            "Main Course" to listOf(
+                MenuItem(id = 3, name = "Dal Makhani", description = "Creamy black lentils cooked with butter and spices", price = 300.0, category = "Main Course", in_stock = true),
+                MenuItem(id = 4, name = "Shahi Paneer", description = "Cottage cheese cubes in a rich and creamy gravy", price = 350.0, category = "Main Course", in_stock = false)
+            )
+        )
+        MenuScreenContent(
+            menuItems = menuItems,
+            cartItemCount = 2,
+            onNavigateToCart = {},
+            onNavigateToAdmin = {},
+            onAddToCart = {}
+        )
     }
 }

--- a/app/src/main/java/com/example/restaurantmanager/ui/customer/screen/OrderConfirmationScreen.kt
+++ b/app/src/main/java/com/example/restaurantmanager/ui/customer/screen/OrderConfirmationScreen.kt
@@ -3,15 +3,19 @@ package com.example.restaurantmanager.ui.customer.screen
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.restaurantmanager.data.local.model.CartItem
+import com.example.restaurantmanager.data.local.model.MenuItem
 import com.example.restaurantmanager.ui.customer.viewmodel.CartViewModel
 import com.example.restaurantmanager.ui.customer.viewmodel.OrderViewModel
+import com.example.restaurantmanager.ui.theme.RestaurantManagerTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -22,27 +26,49 @@ fun OrderConfirmationScreen(
 ) {
     var customerName by remember { mutableStateOf("") }
 
+    OrderConfirmationScreenContent(
+        customerName = customerName,
+        onCustomerNameChange = { customerName = it },
+        cartItems = cartViewModel.cartItems,
+        subtotal = cartViewModel.subtotal,
+        parcelCharges = cartViewModel.parcelCharges,
+        grandTotal = cartViewModel.grandTotal,
+        onPlaceOrder = {
+            orderViewModel.placeOrder(
+                customerName = customerName,
+                cartItems = cartViewModel.cartItems,
+                total = cartViewModel.grandTotal,
+                onOrderPlaced = { orderId ->
+                    cartViewModel.clear()
+                    onPlaceOrder(orderId)
+                }
+            )
+        }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OrderConfirmationScreenContent(
+    customerName: String,
+    onCustomerNameChange: (String) -> Unit,
+    cartItems: List<CartItem>,
+    subtotal: Double,
+    parcelCharges: Double,
+    grandTotal: Double,
+    onPlaceOrder: () -> Unit
+) {
     Scaffold(
         topBar = {
             TopAppBar(title = { Text("Confirm Order") })
         },
         bottomBar = {
             Button(
-                onClick = {
-                    orderViewModel.placeOrder(
-                        customerName = customerName,
-                        cartItems = cartViewModel.cartItems,
-                        total = cartViewModel.grandTotal,
-                        onOrderPlaced = { orderId ->
-                            cartViewModel.clear()
-                            onPlaceOrder(orderId)
-                        }
-                    )
-                },
+                onClick = onPlaceOrder,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(16.dp),
-                enabled = customerName.isNotBlank() && cartViewModel.cartItems.isNotEmpty()
+                enabled = customerName.isNotBlank() && cartItems.isNotEmpty()
             ) {
                 Text("Place Order")
             }
@@ -57,7 +83,7 @@ fun OrderConfirmationScreen(
         ) {
             OutlinedTextField(
                 value = customerName,
-                onValueChange = { customerName = it },
+                onValueChange = onCustomerNameChange,
                 label = { Text("Your Name") },
                 modifier = Modifier.fillMaxWidth()
             )
@@ -69,7 +95,7 @@ fun OrderConfirmationScreen(
                 Column(modifier = Modifier.padding(16.dp)) {
                     Text("Order Summary", style = MaterialTheme.typography.titleLarge)
                     Spacer(modifier = Modifier.height(16.dp))
-                    cartViewModel.cartItems.forEach { cartItem ->
+                    cartItems.forEach { cartItem ->
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.SpaceBetween
@@ -84,14 +110,14 @@ fun OrderConfirmationScreen(
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
                         Text("Subtotal:")
-                        Text("₹${cartViewModel.subtotal}")
+                        Text("₹${subtotal}")
                     }
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
                         Text("Parcel Charges:")
-                        Text("₹${cartViewModel.parcelCharges}")
+                        Text("₹${parcelCharges}")
                     }
                     Divider(modifier = Modifier.padding(vertical = 8.dp))
                     Row(
@@ -99,10 +125,40 @@ fun OrderConfirmationScreen(
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
                         Text("Grand Total:", style = MaterialTheme.typography.titleLarge)
-                        Text("₹${cartViewModel.grandTotal}", style = MaterialTheme.typography.titleLarge)
+                        Text("₹${grandTotal}", style = MaterialTheme.typography.titleLarge)
                     }
                 }
             }
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun OrderConfirmationScreenPreview() {
+    RestaurantManagerTheme {
+        val cartItems = listOf(
+            CartItem(
+                menuItem = MenuItem(id = 1, name = "Paneer Tikka", description = "Grilled cottage cheese cubes marinated in spices", price = 250.0, category = "Starters", in_stock = true),
+                dineInQuantity = 1,
+                takeawayQuantity = 1,
+                instructions = "Make it spicy"
+            ),
+            CartItem(
+                menuItem = MenuItem(id = 3, name = "Dal Makhani", description = "Creamy black lentils cooked with butter and spices", price = 300.0, category = "Main Course", in_stock = true),
+                dineInQuantity = 2,
+                takeawayQuantity = 0,
+                instructions = ""
+            )
+        )
+        OrderConfirmationScreenContent(
+            customerName = "John Doe",
+            onCustomerNameChange = {},
+            cartItems = cartItems,
+            subtotal = 850.0,
+            parcelCharges = 20.0,
+            grandTotal = 870.0,
+            onPlaceOrder = {}
+        )
     }
 }


### PR DESCRIPTION
This commit adds Composable Previews to the `MenuScreen`, `CartScreen`, and `OrderConfirmationScreen`.

To enable the previews, the screens have been refactored to use "content" composables that are not tied to the view models. This is a good practice that makes the UI more reusable and easier to test and preview.